### PR TITLE
[sio-model] Add ShEx and RDF Data for Pseudonym and Personal Information Modules

### DIFF
--- a/example-data/turtle/sio-model/personInformation.ttl
+++ b/example-data/turtle/sio-model/personInformation.ttl
@@ -1,0 +1,32 @@
+@prefix : <http://purl.org/ejp-rd/cde/v020/example-rdf/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix sio: <http://semanticscience.org/resource/> .
+@prefix snomedct: <http://purl.bioontology.org/ontology/SNOMEDCT/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+:person1 a obo:NCBITaxon_9606;
+  sio:SIO_000228 :role1, :role2;
+  sio:SIO_000217 :birthDateQuality, :genderQuality .
+
+:birthDateQuality a obo:NCIT_C68615;
+  sio:SIO_000642  :birthDateOutput .
+
+:role1 a obo:OBI_0000093;
+  sio:SIO_000356 :birthDateProcess .
+
+:birthDateProcess sio:SIO_000229 :birthDateOutput .
+
+:birthDateOutput a sio:SIO_000340;
+  sio:SIO_000300 "2020-02-31T12:00:00"^^xsd:dateTime .
+
+
+:role2 a obo:OBI_0000093;
+  sio:SIO_000356 :genderProcess .
+
+:genderQuality a obo:NCIT_C17357;
+  sio:SIO_000642 :genderOutput .
+
+:genderProcess sio:SIO_000229 :genderOutput .
+
+:genderOutput a sio:SIO_000340, snomedct:703118005 .

--- a/example-data/turtle/sio-model/pseudonym.ttl
+++ b/example-data/turtle/sio-model/pseudonym.ttl
@@ -1,0 +1,15 @@
+@prefix : <http://purl.org/ejp-rd/cde/v020/example-rdf/> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix sio: <http://semanticscience.org/resource/> .
+@prefix rdc: <http://rdf.biosemantics.org/ontologies/rd-connect/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+
+:person1 a obo:NCBITaxon_9606;
+  sio:SIO_000228 :role1 .
+
+:role1 a obo:OBI_0000093 .
+
+:identifier1 a rdc:Pseudonym;
+  sio:SIO_000020 :role1;
+  sio:SIO_000300 "1234567890"^^xsd:string .

--- a/example-data/turtle/sio-model/pseudonym.ttl
+++ b/example-data/turtle/sio-model/pseudonym.ttl
@@ -1,7 +1,7 @@
 @prefix : <http://purl.org/ejp-rd/cde/v020/example-rdf/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix sio: <http://semanticscience.org/resource/> .
-@prefix rdc: <http://rdf.biosemantics.org/ontologies/rd-connect/> .
+@prefix edam: <http://edamontology.org/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 
@@ -10,6 +10,6 @@
 
 :role1 a obo:OBI_0000093 .
 
-:identifier1 a rdc:Pseudonym;
+:identifier1 a edam:data_0842;
   sio:SIO_000020 :role1;
   sio:SIO_000300 "1234567890"^^xsd:string .

--- a/shex/consentShape.shex
+++ b/shex/consentShape.shex
@@ -1,7 +1,6 @@
 PREFIX : <http://purl.org/ejp-rd/cde/v010/shex/>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
 PREFIX rdf: <https://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX wdp: <https://www.wikidata.org/wiki/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX sio: <http://semanticscience.org/resource/>
 PREFIX dct: <http://purl.org/dc/terms/>

--- a/shex/sio-model/personInformationShape.shex
+++ b/shex/sio-model/personInformationShape.shex
@@ -1,0 +1,48 @@
+PREFIX : <http://purl.org/ejp-rd/cde/v020/shex/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX sio: <http://semanticscience.org/resource/>
+PREFIX snomedct: <http://purl.bioontology.org/ontology/SNOMEDCT/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+
+:personShape IRI {
+  a [obo:NCBITaxon_9606];
+  sio:SIO_000228 @:personRoleShape+;
+  sio:SIO_000217 @:birthDateShape;
+  sio:SIO_000217 @:genderShape
+}
+
+:personRoleShape IRI {
+  a [obo:OBI_0000093];
+  (sio:SIO_000356 @:birthDateProcessShape|
+  sio:SIO_000356 @:genderProcessShape)
+}
+
+:birthDateProcessShape IRI {
+  sio:SIO_000229 @:birthDateOutputShape
+}
+
+:birthDateShape IRI {
+  a [obo:NCIT_C68615];
+  sio:SIO_000642 @:birthDateOutputShape
+}
+
+:birthDateOutputShape IRI {
+  a [sio:SIO_000340];
+  sio:SIO_000300 xsd:dateTime
+}
+
+
+:genderProcessShape IRI {
+  sio:SIO_000229 @:genderOutputShape
+}
+
+:genderShape IRI {
+  a [obo:NCIT_C17357];
+  sio:SIO_000642 @:genderOutputShape
+}
+
+:genderOutputShape IRI {
+  a [sio:SIO_000340];
+  a [snomedct:703118005 snomedct:394743007 snomedct:394744001 snomedct:703117000]
+}

--- a/shex/sio-model/personInformationShape.shex
+++ b/shex/sio-model/personInformationShape.shex
@@ -8,8 +8,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :personShape IRI {
   a [obo:NCBITaxon_9606];
   sio:SIO_000228 @:personRoleShape+;
-  sio:SIO_000217 @:birthDateShape;
-  sio:SIO_000217 @:genderShape
+  sio:SIO_000217 @:birthDateQualityShape;
+  sio:SIO_000217 @:genderQualityShape
 }
 
 :personRoleShape IRI {
@@ -22,7 +22,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
   sio:SIO_000229 @:birthDateOutputShape
 }
 
-:birthDateShape IRI {
+:birthDateQualityShape IRI {
   a [obo:NCIT_C68615];
   sio:SIO_000642 @:birthDateOutputShape
 }
@@ -37,7 +37,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
   sio:SIO_000229 @:genderOutputShape
 }
 
-:genderShape IRI {
+:genderQualityShape IRI {
   a [obo:NCIT_C17357];
   sio:SIO_000642 @:genderOutputShape
 }

--- a/shex/sio-model/pseudonymShape.shex
+++ b/shex/sio-model/pseudonymShape.shex
@@ -1,7 +1,7 @@
 PREFIX : <http://purl.org/ejp-rd/cde/v020/shex/>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
 PREFIX sio: <http://semanticscience.org/resource/>
-PREFIX rdc: <http://rdf.biosemantics.org/ontologies/rd-connect/>
+PREFIX edam: <http://edamontology.org/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 
@@ -15,7 +15,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 }
 
 :identifierShape IRI {
-  a [rdc:Pseudonym];
+  a [edam:data_0842];
   sio:SIO_000020 @:personRoleShape;
   sio:SIO_000300 xsd:string
 }

--- a/shex/sio-model/pseudonymShape.shex
+++ b/shex/sio-model/pseudonymShape.shex
@@ -1,0 +1,21 @@
+PREFIX : <http://purl.org/ejp-rd/cde/v020/shex/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX sio: <http://semanticscience.org/resource/>
+PREFIX rdc: <http://rdf.biosemantics.org/ontologies/rd-connect/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+
+:personShape IRI {
+  a [obo:NCBITaxon_9606];
+  sio:SIO_000228 @:personRoleShape
+}
+
+:personRoleShape IRI {
+  a [obo:OBI_0000093]
+}
+
+:identifierShape IRI {
+  a [rdc:Pseudonym];
+  sio:SIO_000020 @:personRoleShape;
+  sio:SIO_000300 xsd:string
+}


### PR DESCRIPTION
Note that:
- I still failed to find the unique identifier for `rdc-meta:pseudonym`, and need some help to fix it.
- "Remove Unused Prefix" is the minor change for the original model (not sio-model).
